### PR TITLE
Remove SubfieldBase metaclass from EnumFieldMixin

### DIFF
--- a/enumfields/fields.py
+++ b/enumfields/fields.py
@@ -9,7 +9,9 @@ from django.db.models.fields import NOT_PROVIDED, BLANK_CHOICE_DASH
 
 from .compat import import_string
 
-class EnumFieldMixin(six.with_metaclass(models.SubfieldBase)):
+metaclass = models.SubfieldBase if django.VERSION < (1, 8) else type
+
+class EnumFieldMixin(six.with_metaclass(metaclass)):
     def __init__(self, enum, **options):
         if isinstance(enum, six.string_types):
             self.enum = import_string(enum)
@@ -33,6 +35,9 @@ class EnumFieldMixin(six.with_metaclass(models.SubfieldBase)):
 
     def get_prep_value(self, value):
         return None if value is None else self.enum(value).value
+
+    def from_db_value(self, value, expression, connection, context):
+        return self.to_python(value)
 
     def value_to_string(self, obj):
         """


### PR DESCRIPTION
Deprecated in Django 1.8, see release notes:
https://docs.djangoproject.com/en/1.8/releases/1.8/#subfieldbase